### PR TITLE
Change open uri http://... to https://...

### DIFF
--- a/lib/hackway/session.rb
+++ b/lib/hackway/session.rb
@@ -45,8 +45,9 @@ module Hackway
 
     private
       def monitoring(channel)
-        articles = Nokogiri::HTML(open('http://news.ycombinator.com/news')).search('.title')
-        subtexts = Nokogiri::HTML(open('http://news.ycombinator.com/news')).search('.subtext')
+        news = Nokogiri::HTML(open('https://news.ycombinator.com/news'))
+        articles = news.search('.title')
+        subtexts = news.search('.subtext')
 
         while articles.size > 1
           articles.shift


### PR DESCRIPTION
## 環境
- Ruby 1.9.3-p385
- Debian GNU/Linux 6.0.6 (squeeze)
## 修正対象

news.ycombinator.com/news が http → https リダイレクトするようになったらしく、
下記エラーが発生して記事一覧が取得できていませんでした。

```
#<RuntimeError: redirection forbidden: http://news.ycombinator.com/news -> https://news.ycombinator.com/news>
       /home/gongo/.rbenv/versions/1.9.3-p385/lib/ruby/1.9.1/open-uri.rb:216:in `open_loop'
       /home/gongo/.rbenv/versions/1.9.3-p385/lib/ruby/1.9.1/open-uri.rb:146:in `open_uri'
       /home/gongo/.rbenv/versions/1.9.3-p385/lib/ruby/1.9.1/open-uri.rb:677:in `open'
       /home/gongo/.rbenv/versions/1.9.3-p385/lib/ruby/1.9.1/open-uri.rb:33:in `open'
       /home/gongo/service/hackway/lib/hackway/session.rb:48:in `monitoring'
       /home/gongo/service/hackway/lib/hackway/session.rb:33:in `block (2 levels) in on_user'
       /home/gongo/service/hackway/lib/hackway/session.rb:31:in `loop'
       /home/gongo/service/hackway/lib/hackway/session.rb:31:in `block in on_user'
```
